### PR TITLE
Fix Legal paper size orientation

### DIFF
--- a/source/lib/include/ppp/config.hpp
+++ b/source/lib/include/ppp/config.hpp
@@ -85,7 +85,7 @@ struct Config
 
     std::map<std::string, SizeInfo> m_PageSizes{
         { "Letter", { { 8.5_in, 11_in }, 1_in, 1u } },
-        { "Legal", { { 14_in, 8.5_in }, 1_in, 1u } },
+        { "Legal", { { 8.5_in, 14_in }, 1_in, 1u } },
         { "A5", { { 148.5_mm, 210_mm }, 1_mm, 1u } },
         { "A4", { { 210_mm, 297_mm }, 1_mm, 0u } },
         { "A4+", { { 240_mm, 329_mm }, 1_mm, 0u } },


### PR DESCRIPTION
- Changed Legal paper dimensions from 14x8.5 to 8.5x14 inches
- Fixes issue where Legal paper had inverted orientation

**Note**: I cannot test on my local environment, but this change only modifies a data value with no syntax change. It is here for developer reference.

Reference #19 