### PR TITLE
Add Ledger paper size (11x17 inches) to configuration map

### DIFF
--- a/source/lib/include/ppp/config.hpp
+++ b/source/lib/include/ppp/config.hpp
@@ -86,6 +86,7 @@ struct Config
     std::map<std::string, SizeInfo> m_PageSizes{
         { "Letter", { { 8.5_in, 11_in }, 1_in, 1u } },
         { "Legal", { { 8.5_in, 14_in }, 1_in, 1u } },
+        { "Ledger", { { 11_in, 17_in }, 1_in, 1u } },
         { "A5", { { 148.5_mm, 210_mm }, 1_mm, 1u } },
         { "A4", { { 210_mm, 297_mm }, 1_mm, 0u } },
         { "A4+", { { 240_mm, 329_mm }, 1_mm, 0u } },


### PR DESCRIPTION
This is a simple one-line addition to the m_PageSizes map to add the Ledger size (popular in U.S. in chains like Staples and Office Depot). I have compiled locally, and it worked.