### PR TITLE
Add safety checks to prevent application crashes

### DIFF
--- a/source/lib/source/ppp/image.cpp
+++ b/source/lib/source/ppp/image.cpp
@@ -277,6 +277,12 @@ Image Image::Decode(EncodedImageView buffer)
 
 EncodedImage Image::EncodePng(std::optional<int32_t> compression) const
 {
+    // Safety check: if image is empty, return empty buffer
+    if (m_Impl.empty())
+    {
+        return {};
+    }
+    
     std::vector<int> png_params;
     if (compression.has_value())
     {
@@ -300,6 +306,12 @@ EncodedImage Image::EncodePng(std::optional<int32_t> compression) const
 
 EncodedImage Image::EncodeJpg(std::optional<int32_t> quality) const
 {
+    // Safety check: if image is empty, return empty buffer
+    if (m_Impl.empty())
+    {
+        return {};
+    }
+    
     std::vector<int> jpg_params;
     if (quality.has_value())
     {
@@ -625,6 +637,13 @@ PixelDensity Image::Density(::Size real_size) const
 {
     const auto [w, h]{ Size().pod() };
     const auto [bw, bh]{ (real_size).pod() };
+    
+    // Safety check: if real_size is very small or zero, return a reasonable default
+    if (bw <= 0_m || bh <= 0_m)
+    {
+        return PixelDensity{ 96.0f }; // Default DPI value
+    }
+    
     return dla::math::min(w / bw, h / bh);
 }
 

--- a/source/lib/source/ppp/project/image_ops.cpp
+++ b/source/lib/source/ppp/project/image_ops.cpp
@@ -50,6 +50,14 @@ Image CropImage(const Image& image,
 {
     const Size card_size_with_full_bleed{ card_size + 2 * full_bleed };
     const PixelDensity density{ image.Density(card_size_with_full_bleed) };
+    
+    // Safety check: if density is zero or very small, return the original image
+    if (density <= 0_dpi)
+    {
+        LogInfo("Cropping images...\n{} - DPI calculated: 0, skipping cropping for image", image_name.string());
+        return image;
+    }
+    
     Pixel c{ full_bleed * density };
     {
         const PixelDensity dpi{ (density * 1_in / 1_m) };


### PR DESCRIPTION
I experienced crashes in a few situations with image importing, adjusting margins, and while editing the source code. I believe these changes are an overall improvement to the code.

- Add safety check to Image::Density() to handle zero/negative real sizes
- Add safety check to Image::EncodeJpg() to handle empty images
- Add safety check to Image::EncodePng() to handle empty images
- Add safety check to CropImage() to handle zero density images
- Fixes OpenCV assertion failures when processing problematic images

(Fixed version, compiles)